### PR TITLE
Closes #42: Use nested accordions for Versions

### DIFF
--- a/src/pages/Versions/Versions.css
+++ b/src/pages/Versions/Versions.css
@@ -1,3 +1,4 @@
-.accordianLabel { color:brown; font-weight: bold; font-size: larger; }
+.accordianLabel { color:brown; font-weight: bold;  }
 .bookCodeLabel {font-weight: bold;}
 .secondaryLabel {padding-left: 2em; font-style: italic;}
+ion-accordion.accordion-expanded ion-item[slot="header"] {--background: #efefef;}

--- a/src/pages/Versions/Versions.js
+++ b/src/pages/Versions/Versions.js
@@ -24,28 +24,28 @@ export default function Versions({navState, setNavState, catalog, catalogErrors}
                 <IonItem slot="header">
                     <IonLabel className="accordianLabel">{docSet.id}</IonLabel>
                 </IonItem>
-
+                
                 <IonList slot="content">
-                    {docSet.documents.map((d, n2) => (
-                        <IonItem key={n2}>
-                            <div>
-                                <IonLabel className="bookCodeLabel">
-                                    {d.bookCode} - {d.toc || d.h || d.toc2 || d.toc3}
-                                </IonLabel>
-                                <IonText>
+                    <IonAccordionGroup expand="inset" value={navState.bookCode}>
+                        {docSet.documents.map((d, n2) => (
+                            <IonAccordion key={n2} value={d.bookCode}>
+                                <IonItem slot="header">
+                                    <IonLabel className="accordianLabel">{d.bookCode} - {d.toc || d.h || d.toc2 || d.toc3}</IonLabel>
+                                </IonItem>
+                                <IonText slot="content">
                                     {catalog.docSets[n].documents[n2].cvNumbers
                                         .map((c1) => c1.chapter)
                                         .map((c3, n3) => (
                                             <IonButton key={n3} size="small" color="secondary" fill="outline" doc={docSet.id} book={d.bookCode} chapter={c3} onClick={chapterClick} >{c3}</IonButton>
                                         ))}
                                 </IonText>
-                            </div>
-                        </IonItem>
-                    ))}
+                            </IonAccordion>
+                        ))}
+                    </IonAccordionGroup>
                 </IonList>
             </IonAccordion>
         );
-    }
+    };
 
     return (
         <IonPage>


### PR DESCRIPTION
Closes #42: Use nested accordions for Versions

- [X] the content of each docSet accordion item is another accordion, with one item per document
- [X] by default, the selected document is open (like the selected docSet is opened at present)
- [X] the hierarchy is clearer visually (maybe by indenting the document accordion)