### PR TITLE
Closes #47:Add hideBookNav, hideChapterNav, hideVerseNav to Navigation

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -6,20 +6,21 @@ import BookDropDown from "./BookDropDown";
 import ChapterDropDown from "./ChapterDropDown";
 import VerseDropDown from "./VerseDropDown";
 
-const Navigation = ({ navState, setNavState, catalog }) => {
+const Navigation = ({ navState, setNavState, catalog, columns}) => {
+    const { hideBookNav, hideChapterNav, hideVerseNav } = columns;
     return (
         <>
             <IonCol size={3}>
                 <BibleDropDown navState={navState} setNavState={setNavState} catalog={catalog} />
             </IonCol>
             <IonCol size={3}>
-                <BookDropDown navState={navState} setNavState={setNavState} catalog={catalog} />
+                {hideBookNav || <BookDropDown navState={navState} setNavState={setNavState} catalog={catalog} />}
             </IonCol>
             <IonCol size={3}>
-                <ChapterDropDown navState={navState} setNavState={setNavState} catalog={catalog} />
+                {hideChapterNav || <ChapterDropDown navState={navState} setNavState={setNavState} catalog={catalog} />}
             </IonCol>
             <IonCol size={3}>
-                <VerseDropDown navState={navState} setNavState={setNavState} catalog={catalog} />
+                {hideVerseNav || <VerseDropDown navState={navState} setNavState={setNavState} catalog={catalog} />}
             </IonCol>
         </>
     );
@@ -31,4 +32,5 @@ Navigation.propTypes = {
     navState: PropTypes.object.isRequired,
     setNavState: PropTypes.func.isRequired,
     catalog: PropTypes.object.isRequired,
+    columns: PropTypes.object.isRequired,
 };

--- a/src/components/PageHeader.js
+++ b/src/components/PageHeader.js
@@ -2,16 +2,36 @@ import React from 'react';
 import { IonCol, IonGrid, IonHeader, IonRow, IonTitle, IonToolbar } from '@ionic/react';
 import PropTypes from 'prop-types';
 import Navigation from './Navigation';
+import { useIonRouter } from "@ionic/react";
 
-export default function PageHeader({ title, navState, setNavState, catalog }) {
+export default function PageHeader({ title, navState, setNavState, catalog, columns }) {
     // To do 1. Add drop down selector for Bible Done
     // 2. Add drop down selector Book dropdown - Done
-    // 3. Add drop down selector Chapter dropdown
-    // 4. Add drop down selector verse dropdown
-    // 5. Use navState to show current value
-    // 6. Use setNavState to set new value on change
+    // 3. Add drop down selector Chapter dropdown - Done
+    // 4. Add drop down selector verse dropdown - Doen
+    // 5. Use navState to show current value - Done
+    // 6. Use setNavState to set new value on change - Done
     // 7. Add Next, previous buttons as per the tab ie next chapter /previous chapter on chapters tab
-    // 8. Hide Book, chapter, verse dropdown as per tab
+    // 8. Hide Book, chapter, verse dropdown as per tab - Done
+
+    const router = useIonRouter();
+
+    const getColumns = () => {
+        //current pages- "versions","browseBook","browseChapter","browseVerse","browsePassage","search","print"
+        //default pages to hide columns in, can be overridden via column props: columns = {{hideBookNav:false}}
+        const hideBookPages = ['browsePassage', 'search', 'print'];
+        const hideChaperPages = ['versions', 'browseBook', 'browsePassage', 'search', 'print'];
+        const hideVersePages = ['versions', 'browseBook', 'browseChapter', 'browsePassage', 'search', 'print'];
+        const page = router?.routeInfo?.pathname?.split('/')[1];
+        const _hideBookNav = columns?.hideBookNav ?? hideBookPages.includes(page);
+        const _hideChapterNav = columns?.hideChapterNav ?? hideChaperPages.includes(page);
+        const _hideVerseNav = columns?.hideVerseNav ?? hideVersePages.includes(page);
+        return {
+            hideBookNav: _hideBookNav,
+            hideChapterNav: _hideChapterNav,
+            hideVerseNav: _hideVerseNav,
+        };
+    };
 
     return (
         <IonHeader>
@@ -27,6 +47,7 @@ export default function PageHeader({ title, navState, setNavState, catalog }) {
                             navState={navState}
                             setNavState={setNavState}
                             catalog={catalog}
+                            columns={getColumns()}
                         />
                     </IonRow>
                 </IonGrid>
@@ -40,4 +61,5 @@ PageHeader.propTypes = {
     navState: PropTypes.object.isRequired,
     setNavState: PropTypes.func.isRequired,
     catalog: PropTypes.object.isRequired,
+    columns: PropTypes.object,
 };

--- a/src/components/PageHeader.js
+++ b/src/components/PageHeader.js
@@ -5,14 +5,7 @@ import Navigation from './Navigation';
 import { useIonRouter } from "@ionic/react";
 
 export default function PageHeader({ title, navState, setNavState, catalog, columns }) {
-    // To do 1. Add drop down selector for Bible Done
-    // 2. Add drop down selector Book dropdown - Done
-    // 3. Add drop down selector Chapter dropdown - Done
-    // 4. Add drop down selector verse dropdown - Doen
-    // 5. Use navState to show current value - Done
-    // 6. Use setNavState to set new value on change - Done
-    // 7. Add Next, previous buttons as per the tab ie next chapter /previous chapter on chapters tab
-    // 8. Hide Book, chapter, verse dropdown as per tab - Done
+    // To do: Add Next, previous buttons as per the tab ie next chapter /previous chapter on chapters tab
 
     const router = useIonRouter();
 


### PR DESCRIPTION
Closes #47:Add hideBookNav, hideChapterNav, hideVerseNav to Navigation
- [X] Add `hideBookNav`, `hideChapterNav` and `hideVerseNav` flags to `Navigation` - added it as single prop columns
- [X] Use these flags to not display book, chapter or verse fields. (Keep the column, even when empty, so that the fields do not jump around.)
- [X] Add these flags to the list of possible props for each page, so that the navigation fields displayed can be controlled from the router in App.js - added a default list of pages as per current pages , can be changed as I was not sure of pages to hide the columsn in, default can be overridden via columns prop when required eg. columns = {{hideBookNav:false}}
- [X] Use those flags to hide the chapter and verse navigation for `Versions`, as shown below

Have split the logic between Navigation and PageHeader components as usually PageHeader is called can be combined if required.